### PR TITLE
docs: add RepoCloud as a deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿<div align="center">
+<div align="center">
 
 # Auto Company
 
@@ -353,6 +353,10 @@ Suggested rollout: start with `make start` (foreground), then move to daemon mod
 - [ralph-claude-code](https://github.com/frankbria/ralph-claude-code) - exit signal interception
 - [claude-auto-resume](https://github.com/terryso/claude-auto-resume) - usage-limit resume pattern
 
+## Deploy
+
+[![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/auto-company/)
+
 ## 🤝 Contribution & Contact
 
 Welcome to submit Issues and Pull Requests!
@@ -360,4 +364,3 @@ Any questions or suggestions? Please contact Zheyuan (Max) Kong (Carnegie Mellon
 
 Zheyuan (Max) Kong: kongzheyuan@outlook.com | zheyuank@tepper.cmu.edu
 GitHub: https://github.com/MaxMiksa/Auto-Company
-

--- a/README.md
+++ b/README.md
@@ -353,7 +353,9 @@ Suggested rollout: start with `make start` (foreground), then move to daemon mod
 - [ralph-claude-code](https://github.com/frankbria/ralph-claude-code) - exit signal interception
 - [claude-auto-resume](https://github.com/terryso/claude-auto-resume) - usage-limit resume pattern
 
-## Deploy
+## One-Click Deploy
+
+You can one-click deploy Auto-Company on a VPS and customize with AI agents on RepoCloud
 
 [![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/auto-company/)
 


### PR DESCRIPTION
This PR adds a RepoCloud deploy button to the README, providing users with a one-click cloud deployment option.